### PR TITLE
Remove null-check to more-closely mirror original functionality

### DIFF
--- a/src/AspNet.Identity.EntityFramework.Multitenant/MultitenantUserStore.Generic.cs
+++ b/src/AspNet.Identity.EntityFramework.Multitenant/MultitenantUserStore.Generic.cs
@@ -94,9 +94,6 @@ namespace AspNet.Identity.EntityFramework.Multitenant
         /// <returns>The <typeparamref name="TUser"/> if found; otherwise <c>null</c>.</returns>
         public override Task<TUser> FindByNameAsync(string userName)
         {
-            if (string.IsNullOrWhiteSpace(userName))
-                throw new ArgumentNullException("userName");
-
             ThrowIfInvalid();
             return GetUserAggregateAsync(u => u.UserName == userName && u.TenantId.Equals(TenantId));
         }
@@ -162,9 +159,6 @@ namespace AspNet.Identity.EntityFramework.Multitenant
         /// <returns>The <typeparamref name="TUser"/> if found; otherwise <c>null</c>.</returns>
         public override Task<TUser> FindByEmailAsync(string email)
         {
-            if (string.IsNullOrWhiteSpace(email))
-                throw new ArgumentNullException("email");
-
             ThrowIfInvalid();
             return GetUserAggregateAsync(u => u.Email.ToUpper() == email.ToUpper() && u.TenantId.Equals(TenantId));
         }


### PR DESCRIPTION
We encountered a minor incompatibility when switching from the existing UserStore to the MultitenantUserStore.  In the default UserStore, a search for a blank name or email would return a null.  In the MultitenanctUserStore it throws an exception.  I've modified the MultiTenantUserStore to mirror the functionality from the default.  
